### PR TITLE
Modified regex to detect longer WPA2-PMKID-PBKDF

### DIFF
--- a/regmap.cfg
+++ b/regmap.cfg
@@ -54,7 +54,7 @@
 (^|:)[A-Fa-f0-9]{60}$!112!Oracle (112) - but it needs a hash between the first 40 and last 20 for some reason
 (^|:)[A-Fa-f0-9]{40}:[A-Fa-f0-9]{20}$!112!Oracle (112)
 ^\$cloudkeychain\$!6600!1Password
-(^|:)[a-f0-9]{32}\*[a-f0-9]{12}\*[a-f0-9]{12}\*[0-9]{8}!16800!WPA PMKID
+(^|:)[a-f0-9]{32}\*[a-f0-9]{12}\*[a-f0-9]{12}\*[0-9a-f]{8,20}!16800!WPA PMKID
 (^|:)grub.pbkdf2.sha512!7200!grub
 (^|:)[A-Z0-9]+\$[A-F0-9]{40}!7800!SAP CODVN F/G (PASSCODE)
 (^|:)[A-Z0-9]+\$[A-F0-9]{16}!7700!SAP CODVN B (BCODE)


### PR DESCRIPTION
Through auditing with bettercap/bettercap seems adding [a-f] to the last set and increasing the length from 8 to 8-20 I was able to import all hashes in a provided .16800 file